### PR TITLE
Add release channel to url

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,10 +3,15 @@ module.exports = ({ url, iosManifest, config }) => {
   const slack = require('slack-notify')(webhookUrl);
 
   return new Promise((resolve, reject) => {
+    
+    const releaseChannel = iosManifest.releaseChannel || 'default';
+    const queryString = releaseChannel === 'default' ? '' :
+      '?release-channel='+encodeURIComponent(releaseChannel)
+   
     slack.send(
       {
         icon_url: iosManifest.iconUrl,
-        text: `${iosManifest.name} v${iosManifest.version} published to ${url}`,
+        text: `${iosManifest.name} v${iosManifest.version} published to ${url + queryString}`,
         unfurl_links: 0,
         username: config.username || 'ExpoBot',
       },


### PR DESCRIPTION
@brentvatne wouldn't it make more sense that the url received from this hook does already include the release channel in it instead of building the url in all postpublish hooks?