### PR TITLE
Added support for slack channel override

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@ useful to non-you people, such as your team or your grandparents.
         "file": "expo-postpublish-slack-notify",
         "config": {
           "webhookUrl": "your webhook url here",
-          "username": "thisIsOptionalAndIsAValidSlackUsername"
+          "username": "thisIsOptionalAndIsAValidSlackUsername",
+          "channel": "#channel_other_than_default"
         }
       }
     ]

--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ module.exports = ({ url, iosManifest, config }) => {
         text: `${iosManifest.name} v${iosManifest.version} published to ${url + queryString}`,
         unfurl_links: 0,
         username: config.username || 'ExpoBot',
+        channel: config.channel || ''
       },
       err => {
         if (err) {


### PR DESCRIPTION
Slack treats empty strings as "default" so this overrides the channel if you have one.

You could conceivably add support for "icon_emoji" config variable as well using this same methodology.