### PR TITLE
Use revisionId rather than version

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ module.exports = ({ url, iosManifest, config }) => {
     slack.send(
       {
         icon_url: iosManifest.iconUrl,
-        text: `${iosManifest.name} v${iosManifest.version} published to ${url + queryString}`,
+        text: `${iosManifest.name} v${iosManifest.revisionId} published to ${url + queryString}`,
         unfurl_links: 0,
         username: config.username || 'ExpoBot',
         channel: config.channel || ''


### PR DESCRIPTION
`revisionId` is strictly more useful than just seeing the version. If you publish multiple OTA updates, it's useful to see the `revisionId` so you can make sure that your device has downloaded the latest update. Seeing messages that just specify `v1.0.0` every time is not particularly useful because there's no way to know what went out with that particular publish.